### PR TITLE
add test data from ngff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 
 coverage.xml
 .coverage*
+.idea/

--- a/tests/v06/data_rfc5/coordinate_systems/.config.json
+++ b/tests/v06/data_rfc5/coordinate_systems/.config.json
@@ -1,0 +1,3 @@
+{
+  "schema": "schemas/coordinate_systems_and_transforms.schema"
+}

--- a/tests/v06/data_rfc5/coordinate_systems/.config.json
+++ b/tests/v06/data_rfc5/coordinate_systems/.config.json
@@ -1,3 +1,0 @@
-{
-  "schema": "schemas/coordinate_systems_and_transforms.schema"
-}

--- a/tests/v06/data_rfc5/coordinate_systems/arrayCoordSys.json
+++ b/tests/v06/data_rfc5/coordinate_systems/arrayCoordSys.json
@@ -1,0 +1,10 @@
+{
+  "arrayCoordinateSystem": {
+    "name": "myDataArray",
+    "axes": [
+      { "name": "k", "type": "array" },
+      { "name": "j", "type": "array" },
+      { "name": "i", "type": "array" }
+    ]
+  }
+}

--- a/tests/v06/data_rfc5/transformations/.config.json
+++ b/tests/v06/data_rfc5/transformations/.config.json
@@ -1,0 +1,3 @@
+{
+  "schema": "schemas/coordinate_systems_and_transforms.schema"
+}

--- a/tests/v06/data_rfc5/transformations/.config.json
+++ b/tests/v06/data_rfc5/transformations/.config.json
@@ -1,3 +1,0 @@
-{
-  "schema": "schemas/coordinate_systems_and_transforms.schema"
-}

--- a/tests/v06/data_rfc5/transformations/affine2d2d.json
+++ b/tests/v06/data_rfc5/transformations/affine2d2d.json
@@ -1,0 +1,17 @@
+{
+  "coordinateSystems": [
+    { "name": "ji", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "yx", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "affine",
+      "affine": [
+        [1, 2, 3],
+        [4, 5, 6]
+      ],
+      "input": "ji",
+      "output": "yx"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/affine2d3d.json
+++ b/tests/v06/data_rfc5/transformations/affine2d3d.json
@@ -1,0 +1,21 @@
+{
+  "coordinateSystems": [
+    { "name": "ij", "axes": [{ "name": "i" }, { "name": "j" }] },
+    {
+      "name": "xyz",
+      "axes": [{ "name": "x" }, { "name": "y" }, { "name": "z" }]
+    }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "affine",
+      "affine": [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9]
+      ],
+      "input": "ij",
+      "output": "xyz"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/bijection.json
+++ b/tests/v06/data_rfc5/transformations/bijection.json
@@ -1,0 +1,15 @@
+{
+  "coordinateSystems": [
+    { "name": "src", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "tgt", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "bijection",
+      "forward": { "type": "coordinates", "path": "forward_coordinates" },
+      "inverse": { "type": "coordinates", "path": "inverse_coordinates" },
+      "input": "src",
+      "output": "tgt"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/bijection_verbose.json
+++ b/tests/v06/data_rfc5/transformations/bijection_verbose.json
@@ -1,0 +1,17 @@
+{
+  "type": "bijection",
+  "forward": {
+    "type": "coordinates",
+    "path": "forward_coordinates",
+    "input": "src",
+    "output": "tgt"
+  },
+  "inverse": {
+    "type": "coordinates",
+    "path": "inverse_coordinates",
+    "input": "tgt",
+    "output": "src"
+  },
+  "input": "src",
+  "output": "tgt"
+}

--- a/tests/v06/data_rfc5/transformations/byDimension1.json
+++ b/tests/v06/data_rfc5/transformations/byDimension1.json
@@ -1,0 +1,22 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "translation",
+          "translation": [-1.0],
+          "input": ["i"],
+          "output": ["x"]
+        },
+        { "type": "scale", "scale": [2.0], "input": ["j"], "output": ["y"] }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/byDimension2.json
+++ b/tests/v06/data_rfc5/transformations/byDimension2.json
@@ -1,0 +1,42 @@
+{
+  "coordinateSystems": [
+    {
+      "name": "in",
+      "axes": [
+        { "name": "l", "type": "array" },
+        { "name": "j", "type": "array" },
+        { "name": "k", "type": "array" },
+        { "name": "i", "type": "array" }
+      ]
+    },
+    {
+      "name": "out",
+      "axes": [
+        { "name": "z", "type": "array" },
+        { "name": "y", "type": "array" },
+        { "name": "x", "type": "array" }
+      ]
+    }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "translation",
+          "translation": [1, 3],
+          "input": ["i", "k"],
+          "output": ["y", "x"]
+        },
+        {
+          "type": "scale",
+          "scale": [2],
+          "input": ["j"],
+          "output": ["z"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/byDimensionInvalid1.json
+++ b/tests/v06/data_rfc5/transformations/byDimensionInvalid1.json
@@ -1,0 +1,22 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "translation",
+          "translation": [-1.0],
+          "input": ["i"],
+          "output": ["z"]
+        },
+        { "type": "scale", "scale": [2.0], "input": ["0"], "output": ["y"] }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/byDimensionInvalid2.json
+++ b/tests/v06/data_rfc5/transformations/byDimensionInvalid2.json
@@ -1,0 +1,22 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "translation",
+          "translation": [-1.0],
+          "input": ["i"],
+          "output": ["x"]
+        },
+        { "type": "scale", "scale": [2.0], "input": ["i"], "output": ["x"] }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/byDimensionXarray.json
+++ b/tests/v06/data_rfc5/transformations/byDimensionXarray.json
@@ -1,0 +1,39 @@
+{
+  "coordinateSystems": [
+    {
+      "name": "physical",
+      "axes": [
+        { "name": "x", "type": "space", "unit": "micrometer" },
+        { "name": "y", "type": "space", "unit": "micrometer" }
+      ]
+    },
+    {
+      "name": "array",
+      "axes": [
+        { "name": "dim_0", "type": "array" },
+        { "name": "dim_1", "type": "array" }
+      ]
+    }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "array",
+      "output": "physical",
+      "transformations": [
+        {
+          "type": "coordinates",
+          "path": "xCoordinates",
+          "input": ["dim_0"],
+          "output": ["x"]
+        },
+        {
+          "type": "coordinates",
+          "path": "yCoordinates",
+          "input": ["dim_1"],
+          "output": ["y"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/coordinates1d.json
+++ b/tests/v06/data_rfc5/transformations/coordinates1d.json
@@ -1,0 +1,16 @@
+{
+  "coordinateSystems": [
+    { "name": "i", "axes": [{ "name": "i" }] },
+    { "name": "x", "axes": [{ "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "name": "a coordinate field transform",
+      "type": "coordinates",
+      "path": "i2xCoordinates",
+      "input": "i",
+      "output": "x",
+      "interpolation": "nearest"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/displacement1d.json
+++ b/tests/v06/data_rfc5/transformations/displacement1d.json
@@ -1,0 +1,16 @@
+{
+  "coordinateSystems": [
+    { "name": "i", "axes": [{ "name": "i" }] },
+    { "name": "x", "axes": [{ "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "name": "a displacement field transform",
+      "type": "displacements",
+      "path": "i2xCoordinates",
+      "input": "i",
+      "output": "x",
+      "interpolation": "nearest"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/identity.json
+++ b/tests/v06/data_rfc5/transformations/identity.json
@@ -1,0 +1,9 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    { "type": "identity", "input": "in", "output": "out" }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/inverseOf.json
+++ b/tests/v06/data_rfc5/transformations/inverseOf.json
@@ -1,0 +1,20 @@
+{
+  "coordinateSystems": [
+    {
+      "name": "moving",
+      "axes": [{ "name": "y-moving" }, { "name": "x-moving" }]
+    },
+    { "name": "fixed", "axes": [{ "name": "y-fixed" }, { "name": "x-fixed" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "inverseOf",
+      "transformation": {
+        "type": "displacements",
+        "path": "path/to/displacements"
+      },
+      "input": "moving",
+      "output": "fixed"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/mapAxis1.json
+++ b/tests/v06/data_rfc5/transformations/mapAxis1.json
@@ -1,0 +1,23 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out1", "axes": [{ "name": "y" }, { "name": "x" }] },
+    { "name": "out2", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "name": "equivalent to identity",
+      "type": "mapAxis",
+      "mapAxis": { "x": "i", "y": "j" },
+      "input": "in",
+      "output": "out1"
+    },
+    {
+      "name": "permutation",
+      "type": "mapAxis",
+      "mapAxis": { "y": "i", "x": "j" },
+      "input": "in",
+      "output": "out2"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/mapAxis2.json
+++ b/tests/v06/data_rfc5/transformations/mapAxis2.json
@@ -1,0 +1,26 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "a" }, { "name": "b" }] },
+    { "name": "out_down", "axes": [{ "name": "x" }] },
+    {
+      "name": "out_up",
+      "axes": [{ "name": "z" }, { "name": "y" }, { "name": "x" }]
+    }
+  ],
+  "coordinateTransformations": [
+    {
+      "name": "projection down",
+      "type": "mapAxis",
+      "mapAxis": { "x": "b" },
+      "input": "in",
+      "output": "out_down"
+    },
+    {
+      "name": "projection up",
+      "type": "mapAxis",
+      "mapAxis": { "z": "b", "y": "b", "x": "a" },
+      "input": "in",
+      "output": "out_up"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/rotation.json
+++ b/tests/v06/data_rfc5/transformations/rotation.json
@@ -1,0 +1,17 @@
+{
+  "coordinateSystems": [
+    { "name": "ji", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "yx", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "rotation",
+      "rotation": [
+        [0, -1],
+        [1, 0]
+      ],
+      "input": "ji",
+      "output": "yx"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/scale.json
+++ b/tests/v06/data_rfc5/transformations/scale.json
@@ -1,0 +1,14 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "scale",
+      "scale": [3.12, 2],
+      "input": "in",
+      "output": "out"
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/sequence.json
+++ b/tests/v06/data_rfc5/transformations/sequence.json
@@ -1,0 +1,17 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "sequence",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        { "type": "translation", "translation": [0.1, 0.9] },
+        { "type": "scale", "scale": [2, 3] }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/sequenceSubspace1.json
+++ b/tests/v06/data_rfc5/transformations/sequenceSubspace1.json
@@ -1,0 +1,27 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "i" }, { "name": "j" }] },
+    { "name": "out", "axes": [{ "name": "x" }, { "name": "y" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "sequence",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "coordinates",
+          "path": "/coordinates",
+          "inputAxes": ["i"],
+          "outputAxes": ["x"]
+        },
+        {
+          "type": "scale",
+          "scale": [2.0],
+          "inputAxes": ["j"],
+          "outputAxes": ["y"]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/translation.json
+++ b/tests/v06/data_rfc5/transformations/translation.json
@@ -1,0 +1,14 @@
+{
+  "coordinateSystems": [
+    { "name": "in", "axes": [{ "name": "j" }, { "name": "i" }] },
+    { "name": "out", "axes": [{ "name": "y" }, { "name": "x" }] }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "translation",
+      "input": "in",
+      "output": "out",
+      "translation": [9, -1.42]
+    }
+  ]
+}

--- a/tests/v06/data_rfc5/transformations/xarrayLike.json
+++ b/tests/v06/data_rfc5/transformations/xarrayLike.json
@@ -1,0 +1,39 @@
+{
+  "coordinateSystems": [
+    {
+      "name": "in",
+      "axes": [
+        { "name": "i", "type": "array" },
+        { "name": "j", "type": "array" }
+      ]
+    },
+    {
+      "name": "out",
+      "axes": [
+        { "name": "x", "type": "space" },
+        { "name": "y", "type": "space" }
+      ]
+    }
+  ],
+  "coordinateTransformations": [
+    {
+      "type": "byDimension",
+      "input": "in",
+      "output": "out",
+      "transformations": [
+        {
+          "type": "coordinates",
+          "path": "/xCoordinates",
+          "input": ["i"],
+          "output": ["x"]
+        },
+        {
+          "type": "coordinates",
+          "path": "/yCoordinates",
+          "input": ["j"],
+          "output": ["y"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the test jsons from https://github.com/bogovicj/ngff/tree/coord-transforms/latest/examples to test the implementations of the coordinate transformations / coordinate systems in ome-zarrr-models-py